### PR TITLE
관심사분리

### DIFF
--- a/src/main/kotlin/testDiscordBot/bot/discordAPI/Bot.kt
+++ b/src/main/kotlin/testDiscordBot/bot/discordAPI/Bot.kt
@@ -10,18 +10,19 @@ import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.context.event.ApplicationReadyEvent
 import org.springframework.context.event.EventListener
 import org.springframework.stereotype.Service
-import testDiscordBot.bot.discordAPI.command.AddTaskCommand
-import testDiscordBot.bot.discordAPI.command.ListTaskCommand
-import testDiscordBot.bot.discordAPI.command.NextTaskCommand
-import testDiscordBot.bot.discordRepository.TaskRepository
+import testDiscordBot.bot.discordAPI.command.CommandResolver
 
 @Service
 class Bot(
-    private val taskRepository: TaskRepository,
-
     @Value("\${discord.bot.token}")
-    private val discordToken: String
+    private val discordToken: String,
+    private val commandResolver: CommandResolver,
 ) {
+
+    private suspend fun handleMessageCreateEvent(event: MessageCreateEvent) {
+        val command = commandResolver.resolve(event.message)
+        command.execute(event)
+    }
 
     @EventListener(ApplicationReadyEvent::class)
     fun botStartCoroutine() {
@@ -30,21 +31,9 @@ class Bot(
         }
     }
 
-    suspend fun botStart() {
+    private suspend fun botStart() {
         val kord = Kord(discordToken)
-
-        kord.on<MessageCreateEvent> {
-            if (message.author?.isBot == true) return@on
-            val command = when {
-                message.content.startsWith("!ADD-TASK") -> AddTaskCommand(taskRepository)
-                message.content == "!LIST-TASK" -> ListTaskCommand(taskRepository)
-                message.content == "!NEXT-TASK" -> NextTaskCommand(taskRepository)
-                else -> throw UnsupportedCommandException(this)
-            }
-
-            command.execute(this)
-        }
-
+        kord.on<MessageCreateEvent>(consumer = ::handleMessageCreateEvent)
         kord.login {
             @OptIn(PrivilegedIntent::class)
             intents += Intent.MessageContent

--- a/src/main/kotlin/testDiscordBot/bot/discordAPI/Exception.kt
+++ b/src/main/kotlin/testDiscordBot/bot/discordAPI/Exception.kt
@@ -1,8 +1,8 @@
 package testDiscordBot.bot.discordAPI
 
-import dev.kord.core.event.message.MessageCreateEvent
+import dev.kord.core.entity.Message
 
 class UnsupportedCommandException(
-    event: MessageCreateEvent
-) : Exception("Unsupported command invoked, message: ${event.message}")
+    message: Message
+) : Exception("Unsupported command invoked, message: $message")
 

--- a/src/main/kotlin/testDiscordBot/bot/discordAPI/command/CommandResolver.kt
+++ b/src/main/kotlin/testDiscordBot/bot/discordAPI/command/CommandResolver.kt
@@ -1,0 +1,21 @@
+package testDiscordBot.bot.discordAPI.command
+
+import dev.kord.core.entity.Message
+import org.springframework.stereotype.Component
+import testDiscordBot.bot.discordAPI.Command
+import testDiscordBot.bot.discordAPI.UnsupportedCommandException
+import testDiscordBot.bot.discordRepository.TaskRepository
+
+@Component
+class CommandResolver(
+    private val taskRepository: TaskRepository,
+) {
+    fun resolve(message: Message): Command {
+        return when {
+            message.content.startsWith("!ADD-TASK") -> AddTaskCommand(taskRepository)
+            message.content == "!LIST-TASK" -> ListTaskCommand(taskRepository)
+            message.content == "!NEXT-TASK" -> NextTaskCommand(taskRepository)
+            else -> throw UnsupportedCommandException(message)
+        }
+    }
+}


### PR DESCRIPTION
kord 도 한번 래핑해서 kord 초기화 부분과 이벤트 핸들링 부분의 관심사를 분리할 순 있지만 현 시점에서는 과할 수 있다고 생각되어 분리하지 않음.